### PR TITLE
add classifier combine functionality

### DIFF
--- a/pippin/aggregator.py
+++ b/pippin/aggregator.py
@@ -54,7 +54,7 @@ class Aggregator(Task):
         super().__init__(name, output_dir, config=config, dependencies=dependencies)
         self.passed = False
         self.classifiers = [d for d in dependencies if isinstance(d, Classifier)]
-        self.lcfit_deps = [c.get_fit_dependency(output=False) for c in self.classifiers]
+        self.lcfit_deps = [d for c in self.classifiers for d in c.get_fit_dependency(output=False)]
         self.lcfit_names = list(set([l.output["name"] for l in self.lcfit_deps if l is not None]))
         self.output["lcfit_names"] = self.lcfit_names
         if not self.lcfit_names:
@@ -313,7 +313,7 @@ class Aggregator(Task):
                         if "_" in output[0]: #check if photometry is in filename
                             snid = [x.split()[0].split("_")[1].split(".")[0] for x in output]
                             snid = [x[1:] if x.startswith("0") else x for x in snid]
-                        else: 
+                        else:
                             snid = [x.split()[0].split(".")[0] for x in output]
                             snid = [x[1:] if x.startswith("0") else x for x in snid]
                     sntype = [x.split()[1].strip() for x in output]
@@ -475,7 +475,7 @@ class Aggregator(Task):
                 deps = [
                     c
                     for c in classifier_tasks
-                    if mask in c.name and mask_clas in c.name and c.mode == Classifier.PREDICT and c.get_simulation_dependency() == sim_task
+                    if mask in c.name and mask_clas in c.name and c.mode == Classifier.PREDICT and sim_task in c.get_simulation_dependency()
                 ]
                 if len(deps) == 0:
                     deps = [sim_task]

--- a/pippin/classifiers/classifier.py
+++ b/pippin/classifiers/classifier.py
@@ -169,6 +169,10 @@ class Classifier(Task):
             needs_sim, needs_lc = cls.get_requirements(options)
 
             runs = []
+            if "COMBINE_MASK" in config:
+                lcfit_tasks = [task if task.name in config["COMBINE_MASK"] else None for task in lcfit_tasks]
+                sim_tasks = [task if task.name in config["COMBINE_MASK"] else None for task in sim_tasks]
+
             if needs_sim and needs_lc:
                 runs = [(l.dependencies[0], l) for l in lcfit_tasks]
             elif needs_sim:

--- a/pippin/classifiers/classifier.py
+++ b/pippin/classifiers/classifier.py
@@ -193,7 +193,7 @@ class Classifier(Task):
                             regular_tasks.append([(s, None)])
                 runs = [combined_tasks] + regular_tasks
             else:
-                if needs_sim and needs_lc:
+                if needs_lc:
                     runs = [[(l.dependencies[0], l)] for l in lcfit_tasks]
                 elif needs_sim:
                     runs = [[(s, None)] for s in sim_tasks]

--- a/pippin/classifiers/classifier.py
+++ b/pippin/classifiers/classifier.py
@@ -194,9 +194,9 @@ class Classifier(Task):
                 runs = [combined_tasks] + regular_tasks
             else:
                 if needs_sim and needs_lc:
-                    runs = [(l.dependencies[0], l) for l in lcfit_tasks]
+                    runs = [[(l.dependencies[0], l)] for l in lcfit_tasks]
                 elif needs_sim:
-                    runs = [(s, None) for s in sim_tasks]
+                    runs = [[(s, None)] for s in sim_tasks]
                 else:
                     Task.logger.warn(f"Classifier {name} does not need sims or fits. Wat.")
 

--- a/pippin/classifiers/classifier.py
+++ b/pippin/classifiers/classifier.py
@@ -6,7 +6,7 @@ from pippin.dataprep import DataPrep
 from pippin.task import Task
 from pippin.snana_sim import SNANASimulation
 from pippin.snana_fit import SNANALightCurveFit
-
+import pdb
 
 class Classifier(Task):
     """ Classification task
@@ -119,6 +119,7 @@ class Classifier(Task):
                 name += f"_{t['name']}"
         else:
             for t in self.get_simulation_dependency():
+                pdb.set_trace()
                 name += f"_{t.output['name']}"
         return name
 
@@ -249,8 +250,8 @@ class Classifier(Task):
 
                 deps = sim_deps + fit_deps
 
-                sim_name = "_".join([s.name for s in sim_deps if s is not None])
-                fit_name = "_".join([l.name for l in fit_deps if l is not None])
+                sim_name = "_".join([s.name for s in sim_deps if s is not None]) if len(sim_deps) > 0 else None
+                fit_name = "_".join([l.name for l in fit_deps if l is not None]) if len(fit_deps) > 0 else None
 
                 if model is not None:
                     if "/" in model or "." in model:

--- a/pippin/classifiers/classifier.py
+++ b/pippin/classifiers/classifier.py
@@ -6,7 +6,6 @@ from pippin.dataprep import DataPrep
 from pippin.task import Task
 from pippin.snana_sim import SNANASimulation
 from pippin.snana_fit import SNANALightCurveFit
-import pdb
 
 class Classifier(Task):
     """ Classification task
@@ -119,7 +118,6 @@ class Classifier(Task):
                 name += f"_{t['name']}"
         else:
             for t in self.get_simulation_dependency():
-                pdb.set_trace()
                 name += f"_{t.output['name']}"
         return name
 

--- a/pippin/classifiers/scone.py
+++ b/pippin/classifiers/scone.py
@@ -111,7 +111,7 @@ class SconeClassifier(Classifier):
               "REPLACE_LOGFILE": str(Path(self.output_dir) / "output.log"),
               "REPLACE_MEM": "8GB",
               "REPLACE_WALLTIME": "4:00:00" if self.gpu else "12:00:00", # 4h is max for gpu
-              "APPEND": ["#SBATCH --ntasks=1"] #"#SBATCH --cpus-per-task=8"]
+              "APPEND": ["#SBATCH --ntasks=1", "#SBATCH -A dessn", "#SBATCH -q regular"]
               }
       model_sbatch_header = self.make_sbatch_header("MODEL_BATCH_FILE", header_dict, use_gpu=self.gpu)
 
@@ -149,8 +149,8 @@ class SconeClassifier(Classifier):
       sim_dep = self.get_simulation_dependency()
       sim_dirs = sim_dep.output["photometry_dirs"][self.index] # if multiple realizations, get only the current one with self.index
 
-      lcdata_paths = self._get_lcdata_paths(sim_dirs)
-      metadata_paths = [path.replace("PHOT", "HEAD") for path in lcdata_paths]
+      lcdata_paths = [path for path in self._get_lcdata_paths(sim_dirs) if "PHOT.FITS" in path]
+      metadata_paths = [path.replace("PHOT.FITS", "HEAD.FITS") for path in lcdata_paths]
 
       str_config = self._make_config(metadata_paths, lcdata_paths, mode, heatmaps_created)
       new_hash = self.get_hash_from_string(str_config)

--- a/pippin/classifiers/scone.py
+++ b/pippin/classifiers/scone.py
@@ -148,7 +148,7 @@ class SconeClassifier(Classifier):
       heatmaps_created = self._heatmap_creation_success() and self.keep_heatmaps
 
       sim_deps = self.get_simulation_dependency()
-      sim_dirs = [sim_dep.output["photometry_dirs"][self.index] for sim_dep in sim_deps] if self.combine_mask else [sim_dep.output["photometry_dirs"] for sim_dep in sim_deps] # if multiple realizations, get only the current one with self.index
+      sim_dirs = [sim_dep.output["photometry_dirs"][self.index] for sim_dep in sim_deps]
 
       lcdata_paths = [path for path in self._get_lcdata_paths(sim_dirs) if "PHOT.FITS" in path]
       metadata_paths = [path.replace("PHOT.FITS", "HEAD.FITS") for path in lcdata_paths]


### PR DESCRIPTION
add COMBINE_MASK functionality to allow multiple sim/lcfit directories to go into one classifier task, useful for training when sim tasks are separated into Ia and CC.

note: only works with SCONE, fitprob, perfect. SNN needs an internal change to accept a list of fits directories instead of a single one. did not check SNIRF.